### PR TITLE
Undefine allocator functions for T_DATA classes

### DIFF
--- a/ext/zoom/rbzoomconnection.c
+++ b/ext/zoom/rbzoomconnection.c
@@ -300,6 +300,8 @@ Init_zoom_connection (VALUE mZoom)
     VALUE c;
 
     c = rb_define_class_under (mZoom, "Connection", rb_cObject); 
+    rb_undef_alloc_func(c);
+
     rb_define_singleton_method (c, "open", rbz_connection_open, -1);
     rb_define_singleton_method (c, "new", rbz_connection_new, -1);
     rb_define_method (c, "connect", rbz_connection_connect, -1);

--- a/ext/zoom/rbzoompackage.c
+++ b/ext/zoom/rbzoompackage.c
@@ -159,6 +159,7 @@ Init_zoom_package (VALUE mZoom)
     VALUE c;
     
     c = rb_define_class_under (mZoom, "Package", rb_cObject); 
+    rb_undef_alloc_func(c);
 
 	/* Remove the default constructor to force initialization through Connection#package. */
     rb_undef_method (CLASS_OF (c), "new");

--- a/ext/zoom/rbzoomquery.c
+++ b/ext/zoom/rbzoomquery.c
@@ -115,6 +115,8 @@ Init_zoom_query (VALUE mZoom)
     VALUE c;
 
     c = rb_define_class_under (mZoom, "Query", rb_cObject); 
+    rb_undef_alloc_func(c);
+
     rb_define_singleton_method (c, "new_prefix", rbz_query_new_prefix, 1);
     rb_define_singleton_method (c, "new_cql", rbz_query_new_cql, 1);
     rb_define_singleton_method (c, "new_sort_by", rbz_query_new_sort_by, 1);

--- a/ext/zoom/rbzoomrecord.c
+++ b/ext/zoom/rbzoomrecord.c
@@ -177,6 +177,8 @@ Init_zoom_record (VALUE mZoom)
     VALUE c;
     
     c = rb_define_class_under (mZoom, "Record", rb_cObject); 
+    rb_undef_alloc_func(c);
+
     rb_undef_method (CLASS_OF (c), "new");
 
     rb_define_method (c, "database", rbz_record_database, -1);

--- a/ext/zoom/rbzoomresultset.c
+++ b/ext/zoom/rbzoomresultset.c
@@ -244,6 +244,8 @@ Init_zoom_resultset (VALUE mZoom)
     VALUE c;
     
     c = rb_define_class_under (mZoom, "ResultSet", rb_cObject); 
+    rb_undef_alloc_func(c);
+
     rb_undef_method (CLASS_OF (c), "new");
     rb_define_method (c, "set_option", rbz_resultset_set_option, 2);
     rb_define_method (c, "get_option", rbz_resultset_get_option, 1);


### PR DESCRIPTION
This silences the corresponding warnings when running with Ruby 3.2.
