### PR TITLE
Bump RuboCop version and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/alexandria-zoom.gemspec
+++ b/alexandria-zoom.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rake-compiler", "~> 1.2"
   s.add_development_dependency "rake-manifest", "~> 0.2.0"
-  s.add_development_dependency "rubocop", "~> 1.41"
+  s.add_development_dependency "rubocop", "~> 1.51"
   s.add_development_dependency "test-unit", "~> 3.3"
 end


### PR DESCRIPTION
- Bump rubocop version
- Require development dependencies to be in the gemspec
