### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   Exclude:
     - 'sample/*'
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/alexandria-zoom.gemspec
+++ b/alexandria-zoom.gemspec
@@ -2,32 +2,36 @@
 
 RUBY_ZOOM_VERSION = "0.6.0"
 
-Gem::Specification.new do |s|
-  s.name = "alexandria-zoom"
-  s.version = RUBY_ZOOM_VERSION
-  s.homepage = "https://github.com/mvz/alexandria-zoom"
-  s.platform = Gem::Platform::RUBY
-  s.author = ["Matijs van Zuijlen", "Laurent Sansonetti", "Ed Summers"]
-  s.summary = <<~TEXT
+Gem::Specification.new do |spec|
+  spec.name = "alexandria-zoom"
+  spec.version = RUBY_ZOOM_VERSION
+  spec.authors = ["Matijs van Zuijlen", "Laurent Sansonetti", "Ed Summers"]
+  spec.email = ["matijs@matijs.net"]
+
+  spec.summary = "Ruby bindings for the Z39.50 Object-Orientation Model (ZOOM)"
+  spec.description = <<~TEXT
     Ruby/ZOOM provides a Ruby binding to the Z39.50 Object-Orientation Model
     (ZOOM), an abstract object-oriented programming interface to a subset of
     the services specified by the Z39.50 standard, also known as the
     international standard ISO 23950.
   TEXT
+  spec.homepage = "https://github.com/mvz/alexandria-zoom"
 
-  s.license = "LGPL-2.1"
-  s.required_ruby_version = ">= 3.0.0"
+  spec.license = "LGPL-2.1"
+  spec.required_ruby_version = ">= 3.1.0"
+  spec.platform = Gem::Platform::RUBY
 
-  s.metadata["rubygems_mfa_required"] = "true"
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["rubygems_mfa_required"] = "true"
 
-  s.files = File.read("Manifest.txt").split
-  s.extensions = "ext/zoom/extconf.rb"
+  spec.files = File.read("Manifest.txt").split
+  spec.extensions = "ext/zoom/extconf.rb"
 
-  s.add_dependency "pkg-config", "~> 1.5.1"
+  spec.add_dependency "pkg-config", "~> 1.5.1"
 
-  s.add_development_dependency "rake", "~> 13.0"
-  s.add_development_dependency "rake-compiler", "~> 1.2"
-  s.add_development_dependency "rake-manifest", "~> 0.2.0"
-  s.add_development_dependency "rubocop", "~> 1.51"
-  s.add_development_dependency "test-unit", "~> 3.3"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-compiler", "~> 1.2"
+  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
+  spec.add_development_dependency "rubocop", "~> 1.51"
+  spec.add_development_dependency "test-unit", "~> 3.3"
 end


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
