### PR TITLE
Clarify license in gemspec

### DIFF
--- a/alexandria-zoom.gemspec
+++ b/alexandria-zoom.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   TEXT
   spec.homepage = "https://github.com/mvz/alexandria-zoom"
 
-  spec.license = "LGPL-2.1"
+  spec.license = "LGPL-2.1-or-later"
   spec.required_ruby_version = ">= 3.1.0"
   spec.platform = Gem::Platform::RUBY
 


### PR DESCRIPTION
This replaces the deprecated and ambiguous license identifier in the gemspec. As per the source files, the code has since long been licensed under the LGPL, version 2.1 or later.
