### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v5
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   Exclude:
     - 'sample/*'
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/alexandria-zoom.gemspec
+++ b/alexandria-zoom.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/mvz/alexandria-zoom"
 
   spec.license = "LGPL-2.1-or-later"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
   spec.platform = Gem::Platform::RUBY
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
- **Require Ruby 3.2 or higher**
- **Bump RuboCop target ruby version**
- **Remove Ruby 3.1 from the CI matrix**
